### PR TITLE
Add per-world permissions and wildcard support

### DIFF
--- a/src/main/kotlin/cc/modlabs/worldengine/commands/WorldCommand.kt
+++ b/src/main/kotlin/cc/modlabs/worldengine/commands/WorldCommand.kt
@@ -113,11 +113,18 @@ private fun addWorldWithGeneratorToBukkitYML(worldName: String, generator: Chunk
     bukkitYml.saveConfig()
 }
 
-private fun hasWorldPermission(player: Player, worldName: String): Boolean {
+fun hasWorldPermission(player: Player, worldName: String): Boolean {
     val basePermission = "worldengine.world"
     val worldPermission = "$basePermission.$worldName"
     val wildcardPermission = "$basePermission.*"
-    val prefixWildcardPermission = "$basePermission.${worldName.split("-")[0]}-*"
 
-    return player.hasPermission(worldPermission) || player.hasPermission(wildcardPermission) || player.hasPermission(prefixWildcardPermission)
+    player.effectivePermissions.forEach { perm ->
+        if (!perm.permission.startsWith(basePermission)) return@forEach
+        if (!perm.permission.contains("*")) return@forEach
+        val worldWildcard = perm.permission.substring(basePermission.length + 1)
+        val regex = worldWildcard.replace("*", "[a-zA-Z0-9_-]*")
+        if (worldName.matches(Regex(regex))) return true
+    }
+
+    return player.hasPermission(worldPermission) || player.hasPermission(wildcardPermission)
 }

--- a/src/main/kotlin/cc/modlabs/worldengine/commands/WorldCommand.kt
+++ b/src/main/kotlin/cc/modlabs/worldengine/commands/WorldCommand.kt
@@ -28,6 +28,11 @@ fun createWorldCommand(): LiteralCommandNode<CommandSourceStack> {
                 logger.info("Executing command `world` with argument ${context.getArgument<String>("world", String::class.java)}")
 
                 val worldName = context.getArgument<String>("world", String::class.java)
+                if (!hasWorldPermission(player, worldName)) {
+                    player.sendMessagePrefixed("commands.world.errors.no-permission", placeholders = mapOf("world" to worldName), default = "<red>You do not have permission to access world {world}")
+                    return@executes Command.SINGLE_SUCCESS
+                }
+
                 val world = Bukkit.getWorld(worldName) ?: Bukkit.createWorld(WorldCreator(worldName)) ?: return@executes run {
                     player.sendMessagePrefixed("commands.world.errors.failed-to-create", placeholders = mapOf("world" to worldName), default = "<red>Failed to create world {world}")
                     Command.SINGLE_SUCCESS
@@ -71,6 +76,11 @@ private fun generateWorld(player: Player, worldName: String, generator: ChunkGen
         return player.sendMessagePrefixed("commands.world.errors.world-already-exists", placeholders = mapOf("world" to worldName), default = "<red>World {world} already exists")
     }
 
+    if (!hasWorldPermission(player, worldName)) {
+        player.sendMessagePrefixed("commands.world.errors.no-permission", placeholders = mapOf("world" to worldName), default = "<red>You do not have permission to generate world {world}")
+        return
+    }
+
     player.sendMessagePrefixed("commands.world.info.creating", placeholders = mapOf("world" to worldName), default = "<green>Creating world {world}")
 
     val world = Bukkit.createWorld(WorldCreator(worldName).generator(generator)) ?: return player.sendMessagePrefixed("commands.world.errors.failed-to-create", placeholders = mapOf("world" to worldName), default = "<red>Failed to create world {world}")
@@ -103,4 +113,11 @@ private fun addWorldWithGeneratorToBukkitYML(worldName: String, generator: Chunk
     bukkitYml.saveConfig()
 }
 
+private fun hasWorldPermission(player: Player, worldName: String): Boolean {
+    val basePermission = "worldengine.world"
+    val worldPermission = "$basePermission.$worldName"
+    val wildcardPermission = "$basePermission.*"
+    val prefixWildcardPermission = "$basePermission.${worldName.split("-")[0]}-*"
 
+    return player.hasPermission(worldPermission) || player.hasPermission(wildcardPermission) || player.hasPermission(prefixWildcardPermission)
+}

--- a/src/main/kotlin/cc/modlabs/worldengine/commands/arguments/WorldArgumentType.kt
+++ b/src/main/kotlin/cc/modlabs/worldengine/commands/arguments/WorldArgumentType.kt
@@ -1,5 +1,6 @@
 package cc.modlabs.worldengine.commands.arguments
 
+import cc.modlabs.worldengine.commands.hasWorldPermission
 import com.mojang.brigadier.arguments.ArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
@@ -11,6 +12,7 @@ import dev.fruxz.stacked.text
 import io.papermc.paper.command.brigadier.MessageComponentSerializer
 import io.papermc.paper.command.brigadier.argument.CustomArgumentType
 import org.bukkit.Bukkit
+import org.bukkit.entity.Player
 import java.util.concurrent.CompletableFuture
 
 class WorldArgumentType : CustomArgumentType.Converted<String, String> {
@@ -32,6 +34,17 @@ class WorldArgumentType : CustomArgumentType.Converted<String, String> {
         builder: SuggestionsBuilder
     ): CompletableFuture<Suggestions> {
         val worlds = getAllBukkitWorlds()
+
+        if (worlds.isEmpty()) return Suggestions.empty()
+
+        if (context.source is Player) {
+            val player = context.source as Player
+            worlds.forEach {
+                if (hasWorldPermission(player, it)) builder.suggest(it)
+            }
+            return builder.buildFuture()
+        }
+
         worlds.forEach { builder.suggest(it) }
         return builder.buildFuture()
     }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -9,6 +9,8 @@ commands:
     info:
       teleported: <green>Teleported.
       creating: <green>Creating world <yellow>{world}
+    errors:
+      no-permission: <red>You do not have permission to access world <yellow>{world}
   worldinfo:
     info:
       currentWorld: You are in the world <yellow>{world}


### PR DESCRIPTION
Fixes #3

Add per-world and wildcard permissions for world access.

* Add `hasWorldPermission` function to check for per-world and wildcard permissions.
* Update `createWorldCommand` function to use `hasWorldPermission` for permission checks.
* Update `generateWorld` function to use `hasWorldPermission` for permission checks.
* Add permission check in `createWorldCommand` to send a message if the player lacks permission.
* Add permission check in `generateWorld` to send a message if the player lacks permission.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ModLabsCC/WorldEngine/pull/5?shareId=02ea34b4-40b1-4c76-85f4-a146c95790cb).